### PR TITLE
#28: Expand /var/env.template into /var/www/.env using envsubst.

### DIFF
--- a/packages/nginx/entrypoint.sh
+++ b/packages/nginx/entrypoint.sh
@@ -4,6 +4,10 @@ set -e
 
 echo "Serializing environment:"
 
+if [ -f /var/env.template ]; then
+    envsubst < /var/env.template > /var/www/.env
+fi
+
 react-env --dest .
 
 cat env.js


### PR DESCRIPTION
This will only do this expansion if /var/env.template is present, and
will act exactly the same as before if it's not. When expanding it, the
use of envsubst means that all substitutions within this file are done
exactly the same as shell expansions. This means that they can reference
values in the shell environment to write into this file.