### PR TITLE
[Feature] Add custom prefix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,28 @@ You are also able to specify the path to a specific env file:
 
 You can use any combination of these two arguments along with the default `.env, .env.local` to build your runtime config. 
 
+#### Specifing an prefix for white-listed environment variables
+
+You are also able to specify the prefix of white-listed environment variables:
+
+```
+{
+  ...
+  "scripts": {
+    "start": "react-env --prefix NEXT_APP -- next start" 
+  }
+  ...
+}
+```
+
+```bash
+# .env
+NEXT_APP_NEXT="Next.js"
+NEXT_APP_CRA="Create React App"
+NEXT_APP_NOT_SECRET_CODE="1234"
+```
+
+
 #### Using with Docker entrypoint
 
 It is possible to use this package as an `ENTRYPOINT` script inside a Dockerfile. This will generate your `__ENV.js` config file when the container boots and allow your `package.json` scripts to remain unchanged. Of course `node` binary must be present in your container.

--- a/packages/node/dist/cli-index.js
+++ b/packages/node/dist/cli-index.js
@@ -15,12 +15,18 @@ function writeBrowserEnvironment(env) {
 }
 
 function getEnvironment() {
-  return Object.keys(process.env)
-    .filter((key) => /^REACT_APP_/i.test(key))
+  const prefix = argv.prefix || "REACT_APP";
+  const envList = Object.keys(process.env)
+    .filter((key) => new RegExp(`^${prefix}_`, 'i').test(key))
     .reduce((env, key) => {
       env[key] = process.env[key];
       return env;
     }, {});
+  if(argv.prefix) {
+    envList['REACT_ENV_PREFIX'] = prefix;
+    process.env.REACT_ENV_PREFIX = prefix;
+  }
+  return envList;
 }
 
 function resolveFile(file) {

--- a/packages/node/dist/index.js
+++ b/packages/node/dist/index.js
@@ -5,8 +5,9 @@ function isBrowser() {
 }
 
 function getFiltered() {
+  const prefix = process.env.REACT_ENV_PREFIX || 'REACT_APP';
   return Object.keys(process.env)
-    .filter((key) => /^REACT_APP_/i.test(key))
+    .filter((key) => new RegExp(`^${prefix}_`, 'i').test(key))
     .reduce((env, key) => {
       env[key] = process.env[key];
       return env;
@@ -14,7 +15,8 @@ function getFiltered() {
 }
 
 function env(key = "") {
-  const safeKey = `REACT_APP_${key}`;
+  const prefix = (isBrowser() ? window.__ENV['REACT_ENV_PREFIX'] : process.env.REACT_ENV_PREFIX) || 'REACT_APP';
+  const safeKey = `${prefix}_${key}`;
   if (isBrowser()) {
     return key.length ? window.__ENV[safeKey] : window.__ENV;
   }

--- a/packages/node/src/__tests__/dotenv.spec.js
+++ b/packages/node/src/__tests__/dotenv.spec.js
@@ -129,3 +129,23 @@ it("can expand env vars", () => {
 
   delete process.env.REACT_APP_ENV;
 });
+
+it('can use custom prefix via --prefix arg', () => {
+  Mock.writeEnvFile(".env", `
+  CUSTOM_PREFIX_FOO=10101
+  CUSTOM_PREFIX_BAR=01010
+  `);
+
+  Mock.run(["--prefix","CUSTOM_PREFIX","--dest","."]);
+
+  expect(process.env.REACT_ENV_PREFIX).toBe("CUSTOM_PREFIX");
+
+  expect(process.env.CUSTOM_PREFIX_FOO).toBe("10101");
+  expect(process.env.CUSTOM_PREFIX_BAR).toBe("01010");
+
+  expect(window.__ENV.CUSTOM_PREFIX_FOO).toBe("10101");
+  expect(window.__ENV.CUSTOM_PREFIX_BAR).toBe("01010");
+
+  delete process.env.CUSTOM_PREFIX_FOO;
+  delete process.env.CUSTOM_PREFIX_BAR;
+})

--- a/packages/node/src/__tests__/dotenv.spec.js
+++ b/packages/node/src/__tests__/dotenv.spec.js
@@ -53,13 +53,12 @@ it("reads env files via -e arg", () => {
 });
 
 it("reads files via --path arg", () => {
-  process.env.ENV = 'foo';
 
   Mock.writeEnvFile(".env.foo", `
   REACT_APP_FOO=10101
   REACT_APP_BAR=01010
   `);
-  Mock.run(["--path","ENV","--dest","."]);
+  Mock.run(["--path",".env.foo","--dest","."]);
 
   expect(window.__ENV.REACT_APP_FOO).toBe("10101");
   expect(window.__ENV.REACT_APP_BAR).toBe("01010");
@@ -70,13 +69,12 @@ it("reads files via --path arg", () => {
 });
 
 it("reads files via -p arg", () => {
-  process.env.ENV = 'bar';
 
   Mock.writeEnvFile(".env.bar", `
   REACT_APP_FOO=1983
   REACT_APP_BAR=3891
   `);
-  Mock.run(["-p","ENV","--dest","."]);
+  Mock.run(["-p",".env.bar","--dest","."]);
 
   expect(window.__ENV.REACT_APP_FOO).toBe("1983");
   expect(window.__ENV.REACT_APP_BAR).toBe("3891");

--- a/packages/node/src/__tests__/index.spec.js
+++ b/packages/node/src/__tests__/index.spec.js
@@ -4,6 +4,7 @@ it("returns a safe value from the browser", () => {
   Object.defineProperty(global, "window", {
     value: {
       __ENV: {
+        REACT_ENV_PREFIX: 'REACT_APP',
         REACT_APP_FOO: "bar",
       },
     },
@@ -63,6 +64,25 @@ it("returns entire safe environment from the server", () => {
     REACT_APP_BAR: "foo",
   });
 });
+
+it('work with the prefix parameters', () => {
+  Object.defineProperty(global, "window", {
+    value: {
+      __ENV: {
+        REACT_ENV_PREFIX: 'CUSTOM_PREFIX',
+        CUSTOM_PREFIX_FOO: "bar",
+        CUSTOM_PREFIX_BAR: "foo",
+      },
+    },
+    writable: true,
+  });
+
+  expect(env()).toEqual({
+    REACT_ENV_PREFIX: 'CUSTOM_PREFIX',
+    CUSTOM_PREFIX_FOO: "bar",
+    CUSTOM_PREFIX_BAR: "foo",
+  });
+})
 
 it("returns undefined when variable does not exist in the browser", () => {
   expect(env("BAM_BAM")).toBe(undefined);

--- a/packages/node/src/cli-index.js
+++ b/packages/node/src/cli-index.js
@@ -15,12 +15,18 @@ function writeBrowserEnvironment(env) {
 }
 
 function getEnvironment() {
-  return Object.keys(process.env)
-    .filter((key) => /^REACT_APP_/i.test(key))
+  const prefix = argv.prefix || "REACT_APP";
+  const envList = Object.keys(process.env)
+    .filter((key) => new RegExp(`^${prefix}_`, 'i').test(key))
     .reduce((env, key) => {
       env[key] = process.env[key];
       return env;
     }, {});
+  if(argv.prefix) {
+    envList['REACT_ENV_PREFIX'] = prefix;
+    process.env.REACT_ENV_PREFIX = prefix;
+  }
+  return envList;
 }
 
 function resolveFile(file) {

--- a/packages/node/src/index.js
+++ b/packages/node/src/index.js
@@ -3,8 +3,9 @@ function isBrowser() {
 }
 
 function getFiltered() {
+  const prefix = process.env.REACT_ENV_PREFIX || 'REACT_APP';
   return Object.keys(process.env)
-    .filter((key) => /^REACT_APP_/i.test(key))
+    .filter((key) => new RegExp(`^${prefix}_`, 'i').test(key))
     .reduce((env, key) => {
       env[key] = process.env[key];
       return env;
@@ -12,7 +13,8 @@ function getFiltered() {
 }
 
 export default function env(key = "") {
-  const safeKey = `REACT_APP_${key}`;
+  const prefix = (isBrowser() ? window.__ENV['REACT_ENV_PREFIX'] : process.env.REACT_ENV_PREFIX) || 'REACT_APP'
+  const safeKey = `${prefix}_${key}`;
   if (isBrowser()) {
     return key.length ? window.__ENV[safeKey] : window.__ENV;
   }


### PR DESCRIPTION
# [Feature] Add custom prefix option

```
{
  ...
  "scripts": {
    "start": "react-env --prefix NEXT_APP -- next start" 
  }
  ...
}
```

```bash
# .env
NEXT_APP_NEXT="Next.js"
NEXT_APP_CRA="Create React App"
NEXT_APP_NOT_SECRET_CODE="1234"
```
Because on our project we would like to use something else than REACT_APP as white-list prefix, I decided to add the option to your lib.

Thank you for providing this package, it helps us a lot :)

I also added a fix to the test that were not passing. You should check your continuous integration since it doesn't report when tests are failing. https://cloud.drone.io/andrewmclagan/react-env/41 (on dotenv.spec.js test)

If you have any questions, feel free to ask :)