### PR TITLE
feat(debug): Only show list of browser environment env if debug is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,13 @@ Specify a specific env file to load e.g. `react-env --path testing` would load `
 
 Change the default destination for generating the `__ENV.js` file.
 
+- `--prefix` **(default: REACT_APP)**
+
+Change the default prefix for white-listed env variables. For exemple `react-env --prefix CUSTOM_PREFIX` will white-list variables like: `CUSTOM_PREFIX_PUBLIC_KEY=my-public-key`
+
+- `--debug` **(default: false)**
+
+Enable debugging for react-env. This will log loaded browser environment variables into your console when running `react-env --debug`
 
 ### 3.x.x Breaking changes
 

--- a/packages/node/dist/cli-index.js
+++ b/packages/node/dist/cli-index.js
@@ -7,9 +7,12 @@ const argv = require("minimist")(process.argv.slice(2), { "--": true });
 function writeBrowserEnvironment(env) {
   const base = fs.realpathSync(process.cwd());
   const dest = argv.d || argv.dest || "public";
+  const debug = argv.debug || false;
   const path = `${base}/${dest}/__ENV.js`;
-  console.debug("Writing runtime env ", path);
-  console.debug(JSON.stringify(env, null, 2));
+  console.info("react-env: Writing runtime env", path);
+  if(debug) {
+    console.debug(JSON.stringify(env, null, 2));
+  }
   const populate = `window.__ENV = ${JSON.stringify(env)};`;
   fs.writeFileSync(path, populate);
 }

--- a/packages/node/src/__tests__/dotenv.spec.js
+++ b/packages/node/src/__tests__/dotenv.spec.js
@@ -1,21 +1,50 @@
 import Mock from "../../testing/mockEnv";
+import fs from 'fs';
+
+const debugSpy = jest.spyOn(console, "debug");
+const infoSpy = jest.spyOn(console, "info");
+
+beforeAll(() => {
+  debugSpy.mockImplementation()
+  infoSpy.mockImplementation()
+});
+
+afterAll(() => {
+  debugSpy.mockRestore();
+  infoSpy.mockRestore();
+});
 
 afterEach(() => {
   Mock.reset();
 });
 
-it("parses safe env vars", () => {
+it("parses safe env vars and", () => {
+  const dest = '.';
+  const base = fs.realpathSync(process.cwd());
+  const pathToEnv = `${base}/${dest}/__ENV.js`;
+
   Mock.writeEnvFile(".env", `
   REACT_APP_FOO=123
   REACT_APP_BAR='hello world'
   `);
-  Mock.run(["--dest","."]);
+  
+  const jsonEnv = JSON.stringify({
+    REACT_APP_FOO: "123",
+    REACT_APP_BAR: 'hello world'
+  }, null, 2)
+
+  Mock.run(["--dest", dest]);
+  
 
   expect(window.__ENV.REACT_APP_FOO).toBe("123");
   expect(window.__ENV.REACT_APP_BAR).toBe("hello world");
 
   delete process.env.REACT_APP_FOO;
   delete process.env.REACT_APP_BAR;
+
+   
+  expect(infoSpy).toHaveBeenCalledWith('react-env: Writing runtime env', pathToEnv)
+  expect(debugSpy).not.toHaveBeenCalledWith(jsonEnv)
 });
 
 it("reads env files via --env arg", () => {
@@ -146,4 +175,26 @@ it('can use custom prefix via --prefix arg', () => {
 
   delete process.env.CUSTOM_PREFIX_FOO;
   delete process.env.CUSTOM_PREFIX_BAR;
+})
+
+it("should show log only if debug params is enabled", () => {
+  Mock.writeEnvFile(".env", `
+  REACT_APP_FOO=123
+  REACT_APP_BAR='hello world'
+  `);
+
+  const jsonEnv = JSON.stringify({
+    REACT_APP_FOO: "123",
+    REACT_APP_BAR: 'hello world'
+  }, null, 2)
+
+  Mock.run(["--debug", '--dest', '.']);
+
+  expect(window.__ENV.REACT_APP_FOO).toBe("123");
+  expect(window.__ENV.REACT_APP_BAR).toBe("hello world");
+
+  delete process.env.REACT_APP_FOO;
+  delete process.env.REACT_APP_BAR;
+
+  expect(debugSpy).toHaveBeenCalledWith(jsonEnv)
 })

--- a/packages/node/src/cli-index.js
+++ b/packages/node/src/cli-index.js
@@ -7,9 +7,12 @@ const argv = require("minimist")(process.argv.slice(2), { "--": true });
 function writeBrowserEnvironment(env) {
   const base = fs.realpathSync(process.cwd());
   const dest = argv.d || argv.dest || "public";
+  const debug = argv.debug || false;
   const path = `${base}/${dest}/__ENV.js`;
-  console.debug("Writing runtime env ", path);
-  console.debug(JSON.stringify(env, null, 2));
+  console.info("react-env: Writing runtime env", path);
+  if(debug) {
+    console.debug(JSON.stringify(env, null, 2));
+  }
   const populate = `window.__ENV = ${JSON.stringify(env)};`;
   fs.writeFileSync(path, populate);
 }


### PR DESCRIPTION
## Feature: Add `--debug` param and remove debug logs by default

Logging browser environment variables into the console by default was a little but annoying. 
Enabling it with a new parameter command is a bit better if you really need to have this information.
Maybe those logs are not really necessary since the file is written directly on the disk, and we can check it manually.
But I also think that the debug param could be useful for the future :)


I also mocked the debug and info console command since we don't want it to output during our test

Also feel free to correct me if the part I added to the README are not really clear :)