### PR TITLE
feat(debug): Only show list of browser environment env if debug is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,20 @@ NEXT_APP_CRA="Create React App"
 NEXT_APP_NOT_SECRET_CODE="1234"
 ```
 
+##### Using prefix with jest
+
+You need to add `REACT_ENV_PREFIX` env variable before jest command if you use `env()` during your tests:
+
+```
+{
+  ...
+  "scripts": {
+    "test": "REACT_ENV_PREFIX=NEXT_APP jest --maxWorkers=3"
+  }
+  ...
+}
+```
+
 
 #### Using with Docker entrypoint
 
@@ -182,6 +196,13 @@ Specify a specific env file to load e.g. `react-env --path testing` would load `
 
 Change the default destination for generating the `__ENV.js` file.
 
+- `--prefix` **(default: REACT_APP)**
+
+Change the default prefix for white-listed env variables. For exemple `react-env --prefix CUSTOM_PREFIX` will white-list variables like: `CUSTOM_PREFIX_PUBLIC_KEY=my-public-key`
+
+- `--debug` **(default: false)**
+
+Enable debugging for react-env. This will log loaded browser environment variables into your console when running `react-env --debug`
 
 ### 3.x.x Breaking changes
 

--- a/packages/node/dist/cli-index.js
+++ b/packages/node/dist/cli-index.js
@@ -7,9 +7,12 @@ const argv = require("minimist")(process.argv.slice(2), { "--": true });
 function writeBrowserEnvironment(env) {
   const base = fs.realpathSync(process.cwd());
   const dest = argv.d || argv.dest || "public";
+  const debug = argv.debug;
   const path = `${base}/${dest}/__ENV.js`;
-  console.debug("Writing runtime env ", path);
-  console.debug(JSON.stringify(env, null, 2));
+  console.info("react-env: Writing runtime env", path);
+  if(debug) {
+    console.debug(`react-env: ${JSON.stringify(env, null, 2)}`);
+  }
   const populate = `window.__ENV = ${JSON.stringify(env)};`;
   fs.writeFileSync(path, populate);
 }

--- a/packages/node/src/cli-index.js
+++ b/packages/node/src/cli-index.js
@@ -7,9 +7,12 @@ const argv = require("minimist")(process.argv.slice(2), { "--": true });
 function writeBrowserEnvironment(env) {
   const base = fs.realpathSync(process.cwd());
   const dest = argv.d || argv.dest || "public";
+  const debug = argv.debug;
   const path = `${base}/${dest}/__ENV.js`;
-  console.debug("Writing runtime env ", path);
-  console.debug(JSON.stringify(env, null, 2));
+  console.info("react-env: Writing runtime env", path);
+  if(debug) {
+    console.debug(`react-env: ${JSON.stringify(env, null, 2)}`);
+  }
   const populate = `window.__ENV = ${JSON.stringify(env)};`;
   fs.writeFileSync(path, populate);
 }


### PR DESCRIPTION
## Feature: Add `--debug` param and remove debug logs by default

Logging browser environment variables into the console by default was a little but annoying. 
Enabling it with a new parameter command is a bit better if you really need to have this information.
Maybe those logs are not really necessary since the file is written directly on the disk, and we can check it manually.
But I also think that the debug param could be useful for the future :)


I also mocked the debug and info console command since we don't want it to output during our test

Also feel free to correct me if the part I added to the README are not really clear :)